### PR TITLE
support messenger 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require": {
     "php": "^7.1",
     "phpgears/cqrs": "~0.3.1",
-    "symfony/messenger": "^4.3"
+    "symfony/messenger": "^4.3|^5.0"
   },
   "require-dev": {
     "brainmaestro/composer-git-hooks": "^2.1",


### PR DESCRIPTION
Hello, appreciate the efforts on phpgears packages. We are using the cqrs package with symfony messenger and would like the integration to support messenger 5.0.

See [changelog](https://github.com/symfony/messenger/blob/5.0/CHANGELOG.md) for both 4.4 and 5.0, it did introducing some breaking changes but this package is not affected in any way. Thanks!